### PR TITLE
force thebaoman to be a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rocky-baoboa @Vitalsine85 @jondwillis
+* @thebaoman @rocky-baoboa @Vitalsine85 @jondwillis


### PR DESCRIPTION
It appears that CODEOWNERS takes precedence over the permission group on the repo. Adding @thebaoman to this list as well to force PR approvals.